### PR TITLE
fix: add Invoice Number column to active subscriptions across multipl…

### DIFF
--- a/static/files/css/style.css
+++ b/static/files/css/style.css
@@ -119,7 +119,7 @@ footer {
     border:1px solid #2f4e85;
 }
 .order-dropdown{
-    width:160px;
+    width:8rem;
     background:#ffffff !important;
     border: 1px solid #2f4e85;
     border-radius: 5px;

--- a/staticfiles/files/css/style.css
+++ b/staticfiles/files/css/style.css
@@ -119,7 +119,7 @@ footer {
     border:1px solid #2f4e85;
 }
 .order-dropdown{
-    width:160px;
+    width:8rem;
     background:#ffffff !important;
     border: 1px solid #2f4e85;
     border-radius: 5px;

--- a/templates/accountant/subscription/active_subscriptions.html
+++ b/templates/accountant/subscription/active_subscriptions.html
@@ -199,6 +199,7 @@
 <th data-hide="phone,tablet" style="text-align:center;">Paid/Total (in KD)</th>
 {% comment %} <th>Contact</th> {% endcomment %}
 <th style="text-align:center;" data-hide="phone,tablet">Debit/Credit</th>
+<th style="text-align:center;" data-hide="phone,tablet">Invoice Number</th>
 <th data-hide="phone,tablet"></th>
 </tr>
 </thead>
@@ -217,6 +218,7 @@
     <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|default_if_none:'0'}}</td>
     {% endif %}
     
+    <td data-label="Remining" style="text-align:center;">INV{{invoice.invoice_no|default_if_none:''}}</td>
     <td data-label="" style="text-align:center;">
     <img {% if invoice.dropzerosamountpaid == invoice.dropzerostotalamount %}src="{% static 'files/images/send_invoice_greay.png' %}"{% else %} {% if invoice.balance <= 0 %}src="{% static 'files/images/send_invoice_green.png' %}" class="clickable-cursor send_invoice"{% else %}src="{% static 'files/images/send_invoice_red.png' %}" class="clickable-cursor send_invoice" {% endif %} {% endif %} align="absmiddle" title="Send Invoice" data-id="{{invoice.id}}" data-blcno="{{invoice.evaluation.evaluation_id}}" data-customername="{{invoice.evaluation.customer.mobile_number}}" data-contactno="{{invoice.evaluation.customer.name}}" {% for schedule in invoice.orderschedules %}{% if forloop.first %}data-startdate="{{schedule.start_at|date:'d-m-Y'}}" {% endif %}{% if forloop.last %}data-enddate="{{schedule.start_at|date:'d-m-Y'}}"{% endif %}{% endfor %} data-totalamount="{{invoice.total_amount|default_if_none:'0.000'|floatformat:'3'}}" data-paidamount="{{invoice.amount_paid|default_if_none:'0.000'|floatformat:'3'}}" data-balance="{{invoice.remining_amount|default_if_none:'0.000'|floatformat:'3'}}" data-remining="{{invoice.balance|default_if_none:'0.000'|floatformat:'3'}}" width="32.5px" height="32.5px">&nbsp&nbsp
     <a href="/customer/subscription/quatation/paw{{invoice.evaluation.evaluation_id|slice:'3:'}}{{invoice.evaluation.customer.username}}" title="View Quotation" target="_blank"><img src="{% static 'files/images/view-icon-green.png' %}" align="absmiddle" class="download-icon"></a>&nbsp&nbsp

--- a/templates/admin/subscription/active_subscriptions.html
+++ b/templates/admin/subscription/active_subscriptions.html
@@ -112,7 +112,7 @@
   <div class="ticket-form-left"><!--ticket-form-left-->
   				<div class=" bold-text common-label"> <label>Cleaning Policy</label></div>
 				<label for="favcity">
-                <select na<td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|default_if_none:'0'}}</td>me="cleaning_policy_filter" id="cleaning_policy_filter_id">
+                <select name="cleaning_policy_filter" id="cleaning_policy_filter_id">
                 <option value=''>---ALL---</option>
                 <option value="ONE TIME SERVICE" {% if fil_cleaning_policy == 'ONE TIME SERVICE' %}selected{%endif%}>ONE TIME SERVICE</option>
                 <option value="SUBSCRIPTION" {% if fil_cleaning_policy == 'SUBSCRIPTION' %}selected{%endif%}>SUBSCRIPTION</option>                
@@ -221,6 +221,7 @@
     <td data-label="" style="text-align:center;">
     <img src="{% static 'files/images/order_blue.png' %}" align="absmiddle" class="clickable-row" data-href="{% url 'bleach_admin:admin-client-orderdetails' invoice.id %}" width="32.5px" height="32.5px">
     </td>
+    <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|default_if_none:'0'}}</td>
     <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.invoice_number|default_if_none:'0'}}</td>
     </tr>
 {% endfor %}

--- a/templates/admin/subscription/active_subscriptions.html
+++ b/templates/admin/subscription/active_subscriptions.html
@@ -112,7 +112,7 @@
   <div class="ticket-form-left"><!--ticket-form-left-->
   				<div class=" bold-text common-label"> <label>Cleaning Policy</label></div>
 				<label for="favcity">
-                <select name="cleaning_policy_filter" id="cleaning_policy_filter_id">
+                <select na<td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|default_if_none:'0'}}</td>me="cleaning_policy_filter" id="cleaning_policy_filter_id">
                 <option value=''>---ALL---</option>
                 <option value="ONE TIME SERVICE" {% if fil_cleaning_policy == 'ONE TIME SERVICE' %}selected{%endif%}>ONE TIME SERVICE</option>
                 <option value="SUBSCRIPTION" {% if fil_cleaning_policy == 'SUBSCRIPTION' %}selected{%endif%}>SUBSCRIPTION</option>                
@@ -199,6 +199,7 @@
 <th data-hide="phone,tablet" style="text-align:center;">Paid/Total (in KD)</th>
 {% comment %} <th>Contact</th> {% endcomment %}
 <th style="text-align:center;" data-hide="phone,tablet">Debit/Credit</th>
+<th style="text-align:center;" data-hide="phone,tablet">Invoice Number</th>
 <th data-hide="phone,tablet"></th>
 </tr>
 </thead>
@@ -220,6 +221,7 @@
     <td data-label="" style="text-align:center;">
     <img src="{% static 'files/images/order_blue.png' %}" align="absmiddle" class="clickable-row" data-href="{% url 'bleach_admin:admin-client-orderdetails' invoice.id %}" width="32.5px" height="32.5px">
     </td>
+    <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.invoice_number|default_if_none:'0'}}</td>
     </tr>
 {% endfor %}
 </tbody>

--- a/templates/agent/subscription/active_subscriptions.html
+++ b/templates/agent/subscription/active_subscriptions.html
@@ -199,6 +199,7 @@
 <th data-hide="phone,tablet" style="text-align:center;">Paid/Total (in KD)</th>
 {% comment %} <th>Contact</th> {% endcomment %}
 <th style="text-align:center;" data-hide="phone,tablet">Debit/Credit</th>
+<th style="text-align:center;" data-hide="phone,tablet">Invoice Number</th>
 <th data-hide="phone,tablet"></th>
 </tr>
 </thead>
@@ -216,6 +217,8 @@
     {% else %}
     <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|default_if_none:'0'}}</td>
     {% endif %}
+
+    <td data-label="Remining" style="text-align:center;">INV{{invoice.invoice_no|default_if_none:''}}</td>
     
     <td data-label="" style="text-align:center;">
     <img {% if invoice.dropzerosamountpaid == invoice.dropzerostotalamount %}src="{% static 'files/images/send_invoice_greay.png' %}"{% else %} {% if invoice.balance <= 0 %}src="{% static 'files/images/send_invoice_green.png' %}" class="clickable-cursor send_invoice"{% else %}src="{% static 'files/images/send_invoice_red.png' %}" class="clickable-cursor send_invoice" {% endif %} {% endif %} title="Send Invoice" align="absmiddle" data-id="{{invoice.id}}" data-blcno="{{invoice.evaluation.evaluation_id}}" data-customername="{{invoice.evaluation.customer.mobile_number}}" data-contactno="{{invoice.evaluation.customer.name}}" {% for schedule in invoice.orderschedules %}{% if forloop.first %}data-startdate="{{schedule.start_at|date:'d-m-Y'}}" {% endif %}{% if forloop.last %}data-enddate="{{schedule.start_at|date:'d-m-Y'}}"{% endif %}{% endfor %} data-totalamount="{{invoice.total_amount|default_if_none:'0.000'|floatformat:'3'}}" data-paidamount="{{invoice.amount_paid|default_if_none:'0.000'|floatformat:'3'}}" data-balance="{{invoice.remining_amount|default_if_none:'0.000'|floatformat:'3'}}" data-remining="{{invoice.balance|default_if_none:'0.000'|floatformat:'3'}}" width="32.5px" height="32.5px">&nbsp&nbsp

--- a/templates/bookingofficer/subscription/active_subscriptions.html
+++ b/templates/bookingofficer/subscription/active_subscriptions.html
@@ -199,6 +199,7 @@
 <th data-hide="phone,tablet" style="text-align:center;">Paid/Total (in KD)</th>
 {% comment %} <th>Contact</th> {% endcomment %}
 <th style="text-align:center;" data-hide="phone,tablet">Debit/Credit</th>
+<th style="text-align:center;" data-hide="phone,tablet">Invoice Number</th>
 <th data-hide="phone,tablet"></th>
 </tr>
 </thead>
@@ -217,6 +218,7 @@
     <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|default_if_none:'0'}}</td>
     {% endif %}
     
+    <td data-label="Remining" style="text-align:center;">INV{{invoice.invoice_no|default_if_none:''}}</td>
     <td data-label="" style="text-align:center;">
     <img {% if invoice.dropzerosamountpaid == invoice.dropzerostotalamount %}src="{% static 'files/images/send_invoice_greay.png' %}"{% else %} {% if invoice.balance <= 0 %}src="{% static 'files/images/send_invoice_green.png' %}" class="clickable-cursor send_invoice"{% else %}src="{% static 'files/images/send_invoice_red.png' %}" class="clickable-cursor send_invoice" {% endif %} {% endif %} align="absmiddle" title="Send Invoice" data-id="{{invoice.id}}" data-blcno="{{invoice.evaluation.evaluation_id}}" data-customername="{{invoice.evaluation.customer.mobile_number}}" data-contactno="{{invoice.evaluation.customer.name}}" {% for schedule in invoice.orderschedules %}{% if forloop.first %}data-startdate="{{schedule.start_at|date:'d-m-Y'}}" {% endif %}{% if forloop.last %}data-enddate="{{schedule.start_at|date:'d-m-Y'}}"{% endif %}{% endfor %} data-totalamount="{{invoice.total_amount|default_if_none:'0.000'|floatformat:'3'}}" data-paidamount="{{invoice.amount_paid|default_if_none:'0.000'|floatformat:'3'}}" data-balance="{{invoice.remining_amount|default_if_none:'0.000'|floatformat:'3'}}" data-remining="{{invoice.balance|default_if_none:'0.000'|floatformat:'3'}}" width="32.5px" height="32.5px">&nbsp&nbsp
     <a href="/customer/subscription/quatation/paw{{invoice.evaluation.evaluation_id|slice:'3:'}}{{invoice.evaluation.customer.username}}" title="View Quotation" target="_blank"><img src="{% static 'files/images/view-icon-green.png' %}" align="absmiddle" class="download-icon"></a>&nbsp&nbsp

--- a/templates/common/subscription/active_subscriptions.html
+++ b/templates/common/subscription/active_subscriptions.html
@@ -319,6 +319,7 @@
 <th data-hide="phone,tablet" style="text-align:center;">Paid/Total (in KD)</th>
 {% comment %} <th>Contact</th> {% endcomment %}
 <th style="text-align:center;" data-hide="phone,tablet">Debit/Credit</th>
+<th style="text-align:center;" data-hide="phone,tablet">Invoice Number</th>
 <th style="text-align:center;" data-hide="phone,tablet">Shortcuts</th>
 </tr>
 </thead>
@@ -337,6 +338,7 @@
     <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|floatformat:3|default_if_none:'0'}}</td>
     {% endif %}
     
+    <td data-label="Remining" style="text-align:center;">INV{{invoice.invoice_no|default_if_none:''}}</td>
     <td data-label="" style="text-align:center;">
 
     <div class="btn-group" id="actionDropdown">

--- a/templates/salesadmin/subscription/active_subscriptions.html
+++ b/templates/salesadmin/subscription/active_subscriptions.html
@@ -199,6 +199,7 @@
 <th data-hide="phone,tablet" style="text-align:center;">Paid/Total (in KD)</th>
 {% comment %} <th>Contact</th> {% endcomment %}
 <th style="text-align:center;" data-hide="phone,tablet">Debit/Credit</th>
+<th style="text-align:center;" data-hide="phone,tablet">Invoice Number</th>
 <th data-hide="phone,tablet"></th>
 </tr>
 </thead>
@@ -216,7 +217,8 @@
     {% else %}
     <td data-label="Remining" class="red-text" style="text-align:center;font-size:19px;">{{invoice.balance|default_if_none:'0'}}</td>
     {% endif %}
-    
+
+    <td data-label="Remining" style="text-align:center;">INV{{invoice.invoice_no|default_if_none:''}}</td>
     <td data-label="" style="text-align:center;">
     <img {% if invoice.dropzerosamountpaid == invoice.dropzerostotalamount %}src="{% static 'files/images/send_invoice_greay.png' %}"{% else %} {% if invoice.balance <= 0 %}src="{% static 'files/images/send_invoice_green.png' %}" class="clickable-cursor send_invoice"{% else %}src="{% static 'files/images/send_invoice_red.png' %}" class="clickable-cursor send_invoice" {% endif %} {% endif %} align="absmiddle" title="Send Invoice" data-id="{{invoice.id}}" data-blcno="{{invoice.evaluation.evaluation_id}}" data-customername="{{invoice.evaluation.customer.mobile_number}}" data-contactno="{{invoice.evaluation.customer.name}}" {% for schedule in invoice.orderschedules %}{% if forloop.first %}data-startdate="{{schedule.start_at|date:'d-m-Y'}}" {% endif %}{% if forloop.last %}data-enddate="{{schedule.start_at|date:'d-m-Y'}}"{% endif %}{% endfor %} data-totalamount="{{invoice.total_amount|default_if_none:'0.000'|floatformat:'3'}}" data-paidamount="{{invoice.amount_paid|default_if_none:'0.000'|floatformat:'3'}}" data-balance="{{invoice.remining_amount|default_if_none:'0.000'|floatformat:'3'}}" data-remining="{{invoice.balance|default_if_none:'0.000'|floatformat:'3'}}" width="32.5px" height="32.5px">&nbsp&nbsp
     <a href="/customer/subscription/quatation/paw{{invoice.evaluation.evaluation_id|slice:'3:'}}{{invoice.evaluation.customer.username}}" title="View Quotation" target="_blank"><img src="{% static 'files/images/view-icon-green.png' %}" align="absmiddle" class="download-icon"></a>&nbsp&nbsp

--- a/templates/stl/subscription/active_subscriptions.html
+++ b/templates/stl/subscription/active_subscriptions.html
@@ -198,6 +198,7 @@
 <th data-hide="phone" style="text-align:center;">Completed/Total</th>
 {% comment %} <th>Contact</th> {% endcomment %}
 <th style="text-align:center;" data-hide="phone,tablet">Area</th>
+<th style="text-align:center;" data-hide="phone,tablet">Invoice Number</th>
 <th data-hide="phone,tablet"></th>
 </tr>
 </thead>
@@ -210,6 +211,7 @@
     <td data-label="Colmpleted Cleaning" style="text-align:center;">{{invoice.completed_cleanings_count}}/{{invoice.total_cleanings_count}}</td>
         
     <td data-label="Remining" style="text-align:center;">{{invoice.area}}</td>
+    <td data-label="Remining" style="text-align:center;">INV{{invoice.invoice_no|default_if_none:''}}</td>
     
     <td data-label="" style="text-align:center;">
     <img src="{% static 'files/images/order_blue.png' %}" align="absmiddle" class="clickable-row" data-href="{% url 'stl:stl-order-details' invoice.id %}" width="32.5px" height="32.5px">


### PR DESCRIPTION
## What are the changes?

- 237ffc8c8ec48049c4dc0cb8a96a27673d853cd2: Added an "Invoice Number" column to active subscriptions in multiple templates, updating both headers and data display.

## Why are these changes needed?

- 237ffc8c8ec48049c4dc0cb8a96a27673d853cd2: To improve billing transparency and allow users to view invoice numbers directly without opening individual invoices.

## UI 

**Before:**
<img width="1248" height="678" alt="image" src="https://github.com/user-attachments/assets/0f6138fa-4b0c-444e-828a-f8812d15079a" />

**After:**
<img width="1222" height="487" alt="image" src="https://github.com/user-attachments/assets/60990ac9-1fc5-40d6-8999-000dbe5d9a7d" />



