### PR TITLE
fix: add address in quotation and replace "visit(s)" with "Total visit"

### DIFF
--- a/static/files/css/customer/main.css
+++ b/static/files/css/customer/main.css
@@ -1008,3 +1008,6 @@ padding-left: 25px;
 bottom: 0;
 
 }
+.fs-08{
+  font-size: 0.8rem !important;
+}

--- a/templates/customer/quotation.html
+++ b/templates/customer/quotation.html
@@ -298,7 +298,7 @@
               </div>
               <div class="d-flex pt-1 inv-invoice-details pb-4">
                 <div class="w-50 inv-text-left inv-primary-text" >
-                  Visit(s)
+                  Total Visit
                 </div>
                 <div class="w-50 inv-text-right inv-primary-text visits-view" onclick="openVisit()">
                  Show Visits
@@ -410,6 +410,10 @@
                 <div class="col-md-8 col-print-8">
                   <div class="inv-service-title p-2 inv-text-bold">
                     {{evaluation_book.service_type}} - {{book_section.section_name}}
+                  </div>
+                  <!--  -->
+                  <div class="inv-service-title p-2 inv-text-bold">
+                   {{evaluation_detail.address.apartment}}</b>: {% if evaluation_detail.address.floor %}{{evaluation_detail.address.floor}}, {% else %}{% endif %} {{evaluation_detail.address.building}}, {{evaluation_detail.address.block}}, {{evaluation_detail.address.street}},<br> {% if evaluation_detail.address.avenue %}{{evaluation_detail.address.avenue}}, {% else %}{% endif %} {{evaluation_detail.address.area.name}}, {{evaluation_detail.address.governorate.name}}
                   </div>
                   <div class="d-flex mb-10" > {% if evaluation_book.status == 'CANCELLED' %} <div class="status-dot cancel-chip-bg"></div> <div class="ml-2">Cancelled</div> {% endif %}</div>
 

--- a/templates/customer/quotation.html
+++ b/templates/customer/quotation.html
@@ -413,8 +413,8 @@
                   </div>
                   <!--  -->
                   <div class="inv-service-title p-2">
-                    <span>Location : </span>
-                    <span> {{evaluation_detail.address.apartment}}, {% if evaluation_detail.address.floor %}{{evaluation_detail.address.floor}}, {% else %}{% endif %} {{evaluation_detail.address.building}}, {{evaluation_detail.address.block}}, {{evaluation_detail.address.street}},<br> {% if evaluation_detail.address.avenue %}{{evaluation_detail.address.avenue}}, {% else %}{% endif %} {{evaluation_detail.address.area.name}}, {{evaluation_detail.address.governorate.name}}</span>
+                    <span class="fs-08">Location : </span>
+                    <span class="fs-08"> {{evaluation_detail.address.apartment}}, {% if evaluation_detail.address.floor %}{{evaluation_detail.address.floor}}, {% else %}{% endif %} {{evaluation_detail.address.building}}, {{evaluation_detail.address.block}}, {{evaluation_detail.address.street}},<br> {% if evaluation_detail.address.avenue %}{{evaluation_detail.address.avenue}}, {% else %}{% endif %} {{evaluation_detail.address.area.name}}, {{evaluation_detail.address.governorate.name}}</span>
                   </div>
                   <div class="d-flex mb-10" > {% if evaluation_book.status == 'CANCELLED' %} <div class="status-dot cancel-chip-bg"></div> <div class="ml-2">Cancelled</div> {% endif %}</div>
 

--- a/templates/customer/quotation.html
+++ b/templates/customer/quotation.html
@@ -412,8 +412,9 @@
                     {{evaluation_book.service_type}} - {{book_section.section_name}}
                   </div>
                   <!--  -->
-                  <div class="inv-service-title p-2 inv-text-bold">
-                   {{evaluation_detail.address.apartment}}</b>: {% if evaluation_detail.address.floor %}{{evaluation_detail.address.floor}}, {% else %}{% endif %} {{evaluation_detail.address.building}}, {{evaluation_detail.address.block}}, {{evaluation_detail.address.street}},<br> {% if evaluation_detail.address.avenue %}{{evaluation_detail.address.avenue}}, {% else %}{% endif %} {{evaluation_detail.address.area.name}}, {{evaluation_detail.address.governorate.name}}
+                  <div class="inv-service-title p-2">
+                    <span>Location : </span>
+                    <span> {{evaluation_detail.address.apartment}}, {% if evaluation_detail.address.floor %}{{evaluation_detail.address.floor}}, {% else %}{% endif %} {{evaluation_detail.address.building}}, {{evaluation_detail.address.block}}, {{evaluation_detail.address.street}},<br> {% if evaluation_detail.address.avenue %}{{evaluation_detail.address.avenue}}, {% else %}{% endif %} {{evaluation_detail.address.area.name}}, {{evaluation_detail.address.governorate.name}}</span>
                   </div>
                   <div class="d-flex mb-10" > {% if evaluation_book.status == 'CANCELLED' %} <div class="status-dot cancel-chip-bg"></div> <div class="ml-2">Cancelled</div> {% endif %}</div>
 


### PR DESCRIPTION
## What are the changes?

- cf8877f553e55cbdfdb8d79af1e093815553c019: Added customer address details in the quotation template. Replaced the label "visit(s)" with "Total visit" for better clarity.
- 06ed3eb924fbba485629aa40e0340ffba5c98028 - Updated the formatting of customer address in the quotation template
- 5c71f02735b97218fb5afdf6f05572588535129f: Added a font size utility class to the location label in the quotation template for better readability.

## Why are these changes needed?

- cf8877f553e55cbdfdb8d79af1e093815553c019: Displaying the full address helps customers verify their booking details directly on the quotation. Using "Total visit" improves readability and avoids confusion caused by "visit(s)"
- 06ed3eb924fbba485629aa40e0340ffba5c98028: To present the customer’s address in a clean and user-friendly format.
- 5c71f02735b97218fb5afdf6f05572588535129f: The location label text was too large compared to surrounding elements. Ensures consistent font sizing across the template.

## UI 

**Before:**
<img width="435" height="586" alt="image" src="https://github.com/user-attachments/assets/519e4f25-6c42-4b0c-b2aa-f5f504dd6271" />



**After:**
<img width="589" height="620" alt="image" src="https://github.com/user-attachments/assets/d6866035-655e-4ea3-a84c-e972ba1af835" />





## Task
7. For customers with multiple cleaning locations, the Quotation must display the branch address details or multiple branch names clearly. Additionally, the alignment of this information should be improved to ensure a professional and readable format
30. In the Quotation, the column currently labelled 'Visit' should be renamed to 'Total Visit' for better clarity.




