### PR TITLE
fix: display customer address in the cleaning items section of the invoice

### DIFF
--- a/customer/views.py
+++ b/customer/views.py
@@ -845,7 +845,14 @@ class CustomerInvoice(View):
 
 		price_ranges 		= ServicePriceRange.objects.filter(is_active=True)
 
-		return render(request,"customer/customer_invoice.html",{'order':order,'nonduplicate_schedules':nonduplicate_schedules,'firstname':firstname,'lastname':lastname,'customer_ip_address':customer_ip_address,"price_ranges":price_ranges})		
+		#service details
+		try:
+			order_details = Order.objects.select_related('evaluation__customer').prefetch_related(Prefetch('evaluation__evaluation_details', queryset=EvaluationDetails.objects.filter(is_active=True).prefetch_related(Prefetch('evaluation_book_evaluation_details', queryset=EvaluationBook.objects.filter(is_active=True), to_attr='evaluationbooks')), to_attr='evaluationdetails')).annotate(customerbooking=Sum(Case(When(Q(evaluation__booking_evaluation__booking_type='CLEANINGBOOKING') & Q(evaluation__booking_evaluation__is_bookingcompleted=False), then=1), default=0, output_field=IntegerField()))).get(is_active=True, evaluation__evaluation_id=evaluation_id, evaluation__customer__username=user_name)
+
+		except:
+			order_details = None
+
+		return render(request,"customer/customer_invoice.html",{'order':order,'nonduplicate_schedules':nonduplicate_schedules,'firstname':firstname,'lastname':lastname,'customer_ip_address':customer_ip_address,"price_ranges":price_ranges,'order_details':order_details})		
 
 	def post(self,request,evaluation_id):
 

--- a/templates/customer/customer_invoice.html
+++ b/templates/customer/customer_invoice.html
@@ -301,6 +301,7 @@
     <!-- Note to the customer ends here-->
     {% endif %}
 
+            {% for evaluation_detail in order_details.evaluation.evaluationdetails %}  
             {% for orderschedule in nonduplicate_schedules %}            
             {% for section in orderschedule.order_scheduler_book.evaluationbooksection %}
             {% if section.order_scheduler_book.service_type.name != 'Kitchen Appliances' %}
@@ -309,6 +310,10 @@
                 <div class="col-md-8 col-print-8">
                   <div class="inv-service-title p-2 inv-text-bold">
                     {{orderschedule.order_scheduler_book.service_type}}-{{section.section_name}}
+                  </div>
+                  <div class="inv-service-title p-2 ">
+                     <span>Location : </span>
+                     <span> {{evaluation_detail.address.apartment}}, {% if evaluation_detail.address.floor %}{{evaluation_detail.address.floor}}, {% else %}{% endif %} {{evaluation_detail.address.building}}, {{evaluation_detail.address.block}}, {{evaluation_detail.address.street}},<br> {% if evaluation_detail.address.avenue %}{{evaluation_detail.address.avenue}}, {% else %}{% endif %} {{evaluation_detail.address.area.name}}, {{evaluation_detail.address.governorate.name}}</span>
                   </div>
                   <div class="d-flex mb-10" > {% if orderschedule.order_scheduler_book.status == 'CANCELLED' %} <div class="status-dot cancel-chip-bg"></div> <div class="ml-2">Cancelled</div> {% endif %}</div>
 
@@ -613,7 +618,7 @@
             </div>
             {% endif %}
             
-                
+            {% endfor %}  
             {% endfor %}
             {% endfor %} 
           

--- a/templates/customer/customer_invoice_subscription.html
+++ b/templates/customer/customer_invoice_subscription.html
@@ -301,6 +301,7 @@
      <!-- Note to the customer ends here-->
      {% endif %}
 
+            {% for evaluation_detail in order_details.evaluation.evaluationdetails %}
             {% for orderschedule in nonduplicate_schedules %}            
             {% for section in orderschedule.order_scheduler_book.evaluationbooksection %}
             {% if section.order_scheduler_book.service_type.name != 'Kitchen Appliances' %}
@@ -309,6 +310,10 @@
                 <div class="col-md-8 col-print-8">
                   <div class="inv-service-title p-2 inv-text-bold">
                     {{orderschedule.order_scheduler_book.service_type}}-{{section.section_name}}
+                  </div>
+                  <div class="inv-service-title p-2 ">
+                     <span>Location : </span>
+                     <span> {{evaluation_detail.address.apartment}}, {% if evaluation_detail.address.floor %}{{evaluation_detail.address.floor}}, {% else %}{% endif %} {{evaluation_detail.address.building}}, {{evaluation_detail.address.block}}, {{evaluation_detail.address.street}},<br> {% if evaluation_detail.address.avenue %}{{evaluation_detail.address.avenue}}, {% else %}{% endif %} {{evaluation_detail.address.area.name}}, {{evaluation_detail.address.governorate.name}}</span>
                   </div>
                   <div class="d-flex mb-10" > {% if orderschedule.order_scheduler_book.status == 'CANCELLED' %} <div class="status-dot cancel-chip-bg"></div> <div class="ml-2">Cancelled</div> {% endif %}</div>
 
@@ -611,7 +616,7 @@
             </div>
             {% endif %}
             
-
+            {% endfor %}
             {% endfor %}
             {% endfor %} 
           


### PR DESCRIPTION
##What are the changes?

- 430ea047a01531d60a8ec03c22a045bbdd64b303: Added customer address to the cleaning items section of the invoice so it is visible along with the service details.

##Why are these changes needed?

- 430ea047a01531d60a8ec03c22a045bbdd64b303: Without the address, invoices for cleaning services lacked important customer details. Displaying the address ensures clarity for both customers and internal records.

## UI 

**Before:**
<img width="663" height="615" alt="screenshot_01_25-08-18_23:44:59" src="https://github.com/user-attachments/assets/2588c624-3f28-4988-8ece-f92e05808077" />

**After:**
<img width="660" height="677" alt="screenshot_01_25-08-18_23:45:26" src="https://github.com/user-attachments/assets/0fe29ab9-c58d-4d09-8d4d-bc84d9784229" />

## Task
17. The Invoice must support the inclusion of multiple addresses for the same customer, allowing selection and display of the relevant address for each specific transaction
