### PR TITLE
fix: show 'Pending' for orders with status null and payment status 'COMPLETED'

### DIFF
--- a/templates/common/client/order-page.html
+++ b/templates/common/client/order-page.html
@@ -1534,7 +1534,7 @@
                     {% elif order.order_status == 'ORDER_CANCELLED' %}
                     <div class="order-status cancelled-status-bg">Cancelled</div>
                     {% else %}
-                    <div class="order-status"></div>
+                    <div class="order-status pending-status-bg">Pending</div>
                     {% endif %}
                 {% else %}
                     {% if order.order_status == 'CANCEL_IN_PROGRESS' %}

--- a/templates/common/order/orders.html
+++ b/templates/common/order/orders.html
@@ -334,7 +334,7 @@
           {% elif order.order_status == 'ORDER_CANCELLED' %}
           <div  class="d-flex "><div class="round-marker cancelled-status-bg"></div><span>Order Cancelled</span></div>
           {% else %}
-          <div  class="d-flex "><div class="round-marker"></div><span></span></div>
+          <div class="d-flex "><div class="round-marker pending-status-bg"></div><span>Pending</span></div>
           {% endif %}
         {% else %}
           {% if order.order_status == 'CANCEL_IN_PROGRESS' %}


### PR DESCRIPTION
## What are the changes?
- ac843cd013d8619bce05604b3986b6ed62daa8e4: Updated order status display logic , Orders with `payment_status = COMPLETED` and `order_status = null` will now show as **Pending**

## Why are these changes needed?
- ac843cd013d8619bce05604b3986b6ed62daa8e4: Currently, if a payment is completed before all cleaning tasks are finished, the order status remains unset (`null`). This creates confusion in the UI, as such orders appear **blank**.  For example, in orders `BLC20250810111` and `BLC20250810112`, payment was completed while the cleaning status was still `CLEANING_TEAM_ASSIGNED`. Because the system validates that the `total cleaning tasks` must equal the `completed tasks` before updating the `status` at the time of `payment`, this mismatch prevented the database from updating the `order status`. This change ensures that in such cases, the order status is displayed as Pending instead of remaining blank in the UI.




## UI
#### Orders list
**Before:**

<img width="1203" height="591" alt="image" src="https://github.com/user-attachments/assets/2c29d49d-9bb2-4d9d-80d9-9b2a174c1e7e" />

> FYI: Order `BLC20250810112` was edited in the local project database, so its status may be different in the screenshot from the one in production.

**After:**
<img width="1202" height="557" alt="image" src="https://github.com/user-attachments/assets/fbe67a21-8e76-450d-829d-f433899ab29e" />

#### Order details page
**Before:**
<img width="1294" height="546" alt="image" src="https://github.com/user-attachments/assets/96cf5c04-bff2-4263-bc6f-44beb5633e10" />


**After:**
<img width="1290" height="583" alt="image" src="https://github.com/user-attachments/assets/21266e59-337b-491d-8d10-82242cf70201" />

## Task

