### PR TITLE
fix: remove print button from invoice subscription and quotation page

### DIFF
--- a/static/files/css/customer/main.css
+++ b/static/files/css/customer/main.css
@@ -1011,3 +1011,7 @@ bottom: 0;
 .fs-08{
   font-size: 0.8rem !important;
 }
+
+.w-150 {
+    width: 150px !important;
+}

--- a/templates/customer/customer_invoice.html
+++ b/templates/customer/customer_invoice.html
@@ -993,15 +993,12 @@
 
               {% endif %}
 
-              <div class="col-5 offset-1 inv-white-btn text-center  mt-4 mb-4 ">
-
-                <i class="fa fa-download" ></i>
-                <a style="text-decoration: none; color: #616161;"  href="/customer/invoice/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>
-              </div> 
-              <div class="col-5 offset-1  inv-white-btn text-center  mt-4 mb-4 " onclick="printDiv()">
-                <i class="fa fa-print"></i>
-                Print
-              </div> 
+              <div class="d-flex col-12 justify-content-center">
+                <div class="col-4 inv-white-btn text-center  mt-4 mb-4 ">
+                  <i class="fa fa-download" ></i>
+                  <a style="text-decoration: none; color: #616161;"  href="/customer/invoice/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>
+                </div> 
+              </div>
             </div>
           </div>
           

--- a/templates/customer/customer_invoice_subscription.html
+++ b/templates/customer/customer_invoice_subscription.html
@@ -984,14 +984,12 @@
               {% endif %}
 
 
-              <div class="col-5 offset-1 inv-white-btn text-center  mt-4 mb-4">
-                <i class="fa fa-download" ></i>
-              <a style="text-decoration: none; color: #616161;" href="/customer/invoice/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>
-              </div> 
-              <div class="col-5 offset-1  inv-white-btn text-center  mt-4 mb-4 " onclick="printDiv()">
-                <i class="fa fa-print"></i>
-                Print
-              </div> 
+              <div class="d-flex col-12 justify-content-center">
+                <div class="col-4 inv-white-btn text-center  mt-4 mb-4 ">
+                  <i class="fa fa-download" ></i>
+                  <a style="text-decoration: none; color: #616161;" href="/customer/invoice/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>
+                </div> 
+              </div>
             </div>
           </div>
           

--- a/templates/customer/quotation.html
+++ b/templates/customer/quotation.html
@@ -961,10 +961,10 @@
        
       </div>
       <div class="d-flex text-center no-print justify-content-center"> 
-        <div class="inv-white-btn text-center  mt-4 mb-4 w-150 " id="download_id">
+        <div class="col-4 inv-white-btn text-center  mt-4 mb-4" id="download_id">
           <input type="hidden" class="filename" value="Quotation_{{order.order_no}}" />
           <i class="fa fa-download" ></i>
-        <a style="text-decoration: none; color: inherit;" href="/customer/quatation/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>
+          <a style="text-decoration: none; color: inherit;" href="/customer/quatation/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>
         </div>
       </div>
       

--- a/templates/customer/quotation.html
+++ b/templates/customer/quotation.html
@@ -960,16 +960,12 @@
         </div>
        
       </div>
-      <div class="d-flex text-center no-print"> 
-        <div class="inv-white-btn text-center  mt-4 mb-4 inv-receipt-download" id="download_id">
+      <div class="d-flex text-center no-print justify-content-center"> 
+        <div class="inv-white-btn text-center  mt-4 mb-4 w-150 " id="download_id">
           <input type="hidden" class="filename" value="Quotation_{{order.order_no}}" />
           <i class="fa fa-download" ></i>
         <a style="text-decoration: none; color: inherit;" href="/customer/quatation/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>
         </div>
-        <div class="inv-white-btn text-center  mt-4 mb-4 inv-receipt-print  " onclick="printDiv()">
-          <i class="fa fa-print"></i>
-          Print
-        </div> 
       </div>
       
    </div>

--- a/templates/customer/quotation.html
+++ b/templates/customer/quotation.html
@@ -961,7 +961,7 @@
        
       </div>
       <div class="d-flex text-center no-print justify-content-center"> 
-        <div class="col-4 inv-white-btn text-center  mt-4 mb-4" id="download_id">
+        <div class="col-2 inv-white-btn text-center  mt-4 mb-4" id="download_id">
           <input type="hidden" class="filename" value="Quotation_{{order.order_no}}" />
           <i class="fa fa-download" ></i>
           <a style="text-decoration: none; color: inherit;" href="/customer/quatation/download/paw{{order.evaluation.evaluation_id|slice:'3:'}}{{order.evaluation.customer.username}}">Download</a>


### PR DESCRIPTION
## What are the changes?
- b078a13e884e98446e1c7fb771ceb76c66268d79 : Removed the print button from the quotation page.
- 4f6abe7a7af11d1a3c57282b6f90ff031f7c027d : Removed the print option from the invoice page.
- 8cf69d7049b8e6eeaf6a09a88d97950ac58b03b8 : Refactored the layout of the invoice download and print buttons. Improved alignment and spacing for better user experience. Ensured consistency with the overall UI design.
- c7958688df13c0b20e21ca57bef8bf5743927650 : Adjusted the layout of the download button in the quotation template. Improved alignment and spacing to match the overall design.
- 70e50ccf270b514d3aa6f67254c524621bfaec6a : Adjusted the width of the download button in the quotation template for better alignment.

## Why are these changes needed?
- b078a13e884e98446e1c7fb771ceb76c66268d79 : The print button was no longer required in the quotation workflow. Prevents users from accessing an unnecessary feature and simplifies the UI.
- 4f6abe7a7af11d1a3c57282b6f90ff031f7c027d : The print option is no longer required in the invoice workflow. Simplifies the user interface and avoids confusion for users.
- 8cf69d7049b8e6eeaf6a09a88d97950ac58b03b8 : Previous button layout caused visual clutter and reduced usability. Enhances readability and provides a cleaner interface for users working with invoices.
- c7958688df13c0b20e21ca57bef8bf5743927650 : The previous layout caused misalignment issues and reduced usability. Provides a cleaner interface and consistent user experience.
- 70e50ccf270b514d3aa6f67254c524621bfaec6a : The previous button width caused UI inconsistency and affected the overall layout. Ensures a cleaner and more consistent user interface in the quotation template.

## UI
### Before**
##### Quotation
<img width="873" height="445" alt="image" src="https://github.com/user-attachments/assets/eae1b0ff-3331-4e63-8b68-db5ff1b918b1" />

##### Subscription
<img width="1070" height="494" alt="image" src="https://github.com/user-attachments/assets/05798d2b-9e3e-4eaf-8291-aebada7a2255" />

##### Invoice
<img width="1086" height="489" alt="image" src="https://github.com/user-attachments/assets/ccf16324-d149-4eeb-b7ac-aeafae62e04f" />



### After**
##### Quotation
<img width="732" height="464" alt="screenshot_01_25-09-09_22:30:09" src="https://github.com/user-attachments/assets/cf75d7a4-2304-4ab7-b444-0259125ef4f8" />

##### Subscription
<img width="1057" height="494" alt="image" src="https://github.com/user-attachments/assets/5b87f244-bdbf-403d-987b-d754bf51648b" />

##### Invoice
<img width="1074" height="549" alt="image" src="https://github.com/user-attachments/assets/69991372-7401-4b25-9c99-00872586114d" />

## Task
25. The 'Print' button should be removed from the Invoice ,quotation form, and only the 'Download' button should be provided to users for accessing the invoice.
