### PR TITLE
fix: add customer address to payment history when order is unscheduled

### DIFF
--- a/customer/views.py
+++ b/customer/views.py
@@ -1843,7 +1843,15 @@ class PaymentReceipt(View):
 					nonduplicate_schedules.append(orderschedule)	
 
 				duplicate_schedules.append(orderschedule.order_scheduler_book)
-
+		else:
+		
+			customer = payment_history.order.evaluation.customer
+			customer_address = Address.objects.filter(customer__id=customer.id, currently_active=True).first()
+			
+			orderschedules = []
+			if customer_address:
+				orderschedules.append(type('OrderSchedule', (), {'customer_address': customer_address})())
+			setattr(payment_history.order, 'orderschedules', orderschedules)		
 
 		return render(request,"customer/voucher.html",{'payment_history':payment_history,'nonduplicate_schedules':nonduplicate_schedules,})
 


### PR DESCRIPTION
### What are the changes?

- fad88a4b1cdd55ad8347e8b35f7e3009d9bbd6d9: Added customer address to the payment history records when the order is unscheduled. Updated logic to handle missing customer details in unscheduled orders.

### Why are these changes needed?

- fad88a4b1cdd55ad8347e8b35f7e3009d9bbd6d9: Previously, customer address was not included in payment history for unscheduled orders. Ensures payment records keep a consistent structure and behaviour across all order types.

### UI

**Before:**
<img width="805" height="510" alt="screenshot_01_25-09-13_21:00:14" src="https://github.com/user-attachments/assets/fe7613ff-0938-4c92-8027-c51c25fc8eaf" />

**After:**
<img width="703" height="463" alt="screenshot_01_25-09-13_20:49:22" src="https://github.com/user-attachments/assets/5f2576d8-ce9f-40c2-b503-e6e3c263da10" />

### TASK
