### PR TITLE
feat: add invoice details modal and display invoice numbers in payment overview

### DIFF
--- a/common_items/views.py
+++ b/common_items/views.py
@@ -1293,6 +1293,12 @@ class PaymentDetails(IsAuthenticated,View):
 		entry_per_page4 = (subscription_due_payments.end_index())-(subscription_due_payments.start_index())+1
 		# entry_per_page5 = (neworder_due_payments.end_index())-(neworder_due_payments.start_index())+1
 
+		# Get the number of invoices generated for the normal_due_payments orders
+		for order in normal_due_payments:
+			order.invoice_count = XeroInvoice.objects.filter(is_active=True,order=order).count()
+			order.invoice_nos = list(XeroInvoice.objects.filter(is_active=True, order=order).values_list('invoice_no', flat=True))
+
+
 		return render(request,'common/payment/payments.html',{'total_transactions':total_transactions,'total_transactions_amount':total_transactions_amount,'total_due_amount':total_due_amount,'total_due_orders':total_due_orders,'total_doubtful_due_amount':total_doubtful_due_amount,'total_doubtful_due_orders':total_doubtful_due_orders,'total_normal_due_amount':total_normal_due_amount,'total_normal_due_orders':total_normal_due_orders,'total_subscription_due_amount':total_subscription_due_amount,'total_subscription_due_orders':total_subscription_due_orders,'tab':tab,'invoices':invoices,"search_query":search,"page_range1":page_range1,"page_range2":page_range2,"page_range3":page_range3,"page_range4":page_range4,"entry_per_page1":entry_per_page1,"entry_per_page2":entry_per_page2,"entry_per_page3":entry_per_page3,"entry_per_page4":entry_per_page4,"no_of_entries":no_of_entries,'transactions':transactions,"doubtful_due_payments":doubtful_due_payments,'normal_due_payments':normal_due_payments,'subscription_due_payments':subscription_due_payments})  #'total_neworder_due_orders':total_neworder_due_orders,'neworder_due_payments':neworder_due_payments',total_neworder_due_amount':total_neworder_due_amount,
 
 	def post(self,request):

--- a/templates/common/payment/payments.html
+++ b/templates/common/payment/payments.html
@@ -37,6 +37,25 @@
   </div>
 </div>
  <!-- notes modal ends here-->
+<!-- Invoice Modal -->
+
+<div class="modal fade" id="invoiceModalCenter" tabindex="-1" role="dialog" aria-labelledby="invoiceModalCenterTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered primary-modal" role="document">
+    <div class="modal-content primary-modal-border">
+      <div class="d-flex">
+        <h5 class="modal-title" id="exampleModalLongTitle">Invoice Details</h5>
+        <button type="button" class="close ml-auto" data-dismiss="modal" aria-label="Close" style="margin-left:auto">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div> 
+      <div class="modal-body">
+       <div class="row">
+           <div class="col-md-12 col-lg-12" id="invoiceNumberList"></div>
+        </div>
+      </div> 
+    </div>
+  </div>
+</div>
 
 {% if request.user.user_type == 'SALESADMIN' %}
   {% include "salesadmin/common/header.html" %}
@@ -557,6 +576,7 @@
         <thead>
         <tr>
         <th class="text-left">Order Number</th>
+        <th class="text-left">Invoice Number </th>
         <th class="text-left" data-hide="phone,tablet">Customer</th>
         <th class="text-left" data-hide="phone,tablet">Service Type</th>
         <th class="text-center" data-hide="phone,tablet">Mobile</th>
@@ -568,10 +588,17 @@
         </thead>
         <tbody>
         {% for invoice in normal_due_payments %}
+
         
         {% if invoice.evaluation.payment_method == 'PREPAID' or invoice.evaluation.payment_method == 'POSTPAID' %}
         <tr {% if invoice.evaluation.payment_way == 'CASH/CHEQUE' %}class="green-line"{% else %}class="gray-line"{% endif %}>
         <td data-label="BLC Number" {% if invoice.evaluation.payment_method == 'PREPAID' %}class="prepaid-line"{% else %}class="postpaid-line"{% endif %}>{{invoice.evaluation.evaluation_id}}</td>
+        <td data-label="Invoice Number">
+          {% if invoice.invoice_count > 1 %}
+          <a href="#" class="show-invoice-popup" data-invoice-numbers="{{invoice.invoice_nos|join:', '}}" data-toggle="modal" data-target="#invoiceModalCenter" data-evaluation-id="{{invoice.evaluation.evaluation_id}}" data-customer-username="{{invoice.evaluation.customer.username}}">INV{{invoice.invoice_no}}</a>
+          {% else %}
+          INV{{invoice.invoice_no}}
+          {% endif %}</td>
         <td data-label="Customer" class="text-left">{{invoice.evaluation.customer.name}}</td>
         <td data-label="Service Type(s)">
         {% for evaluation_details in invoice.evaluation.invoice_evaluation_details %}
@@ -608,6 +635,12 @@
         {% if invoice.preamount_paid != invoice.evaluation.before_cleaning_amount %}
         <tr {% if invoice.evaluation.payment_way == 'CASH/CHEQUE' %}class="green-line"{% else %}class="gray-line"{% endif %}>
         <td data-label="BLC Number" class="prepaid-line">{{invoice.evaluation.evaluation_id}}</td>
+        <td data-label="Invoice Number">
+          {% if invoice.invoice_count > 1 %}
+         <a href="#" class="show-invoice-popup" data-invoice-numbers="{{invoice.invoice_nos|join:', '}}" data-toggle="modal" data-target="#invoiceModalCenter" data-evaluation-id="{{invoice.evaluation.evaluation_id}}" data-customer-username="{{invoice.evaluation.customer.username}}">INV{{invoice.invoice_no}}</a>
+          {% else %}
+          INV{{invoice.invoice_no}}
+          {% endif %}</td>
         <td data-label="Customer" class="text-left">{{invoice.evaluation.customer.name}}</td>
         <td data-label="Service Type(s)">
         {% for evaluation_details in invoice.evaluation.invoice_evaluation_details %}
@@ -635,6 +668,13 @@
         {% if invoice.last_completed and invoice.postamount_paid != invoice.evaluation.after_cleaning_amount %}
         <tr {% if invoice.evaluation.payment_way == 'CASH/CHEQUE' %}class="green-line"{% else %}class="gray-line"{% endif %}>
         <td data-label="BLC Number" >{{invoice.evaluation.evaluation_id}}</td>
+        <td data-label="Invoice Number">
+          {% if invoice.invoice_count > 1 %}
+         <a href="#" class="show-invoice-popup" data-invoice-numbers="{{invoice.invoice_nos|join:', '}}" data-toggle="modal" data-target="#invoiceModalCenter" data-evaluation-id="{{invoice.evaluation.evaluation_id}}" data-customer-username="{{invoice.evaluation.customer.username}}">INV{{invoice.invoice_no}}</a>
+          {% else %}
+          INV{{invoice.invoice_no}}
+          {% endif %}
+        </td>
         <td data-label="Customer" class="text-left">{{invoice.evaluation.customer.name}}</td>
         <td data-label="Service Type(s)">
         {% for evaluation_details in invoice.evaluation.invoice_evaluation_details %}
@@ -1157,8 +1197,21 @@
     $('#order_id').val($(this).data('orderid'));
 
   })
-
+ 
+  $('.show-invoice-popup').click(function() {
+    const orderId = $(this).data('order-id');
+    const invoiceNumbers = $(this).data('invoice-numbers');
+    const evaluationId = $(this).data('evaluation-id').slice(3); // Remove 'BLC' 
+    const customerUsername = $(this).data('customer-username');
+    if(invoiceNumbers && invoiceNumbers.length > 0) {
+      const invoiceList = invoiceNumbers.split(',').map(num => `<div class="col-md-3 col-sm-12 col-xs-12 justify-content-center" style="border: 1px solid #ccc; padding: 1rem; box-shadow: 0 2px 5px rgba(0,0,0,0.1); margin-right: 1rem; cursor:pointer" onclick="window.open('/customer/invoice/prw${evaluationId}${customerUsername}', '_blank')">${`INV${num.trim()}`}</div>`).join('');
+      $('#invoiceNumberList').html(invoiceList);
+    } else {
+      $('#invoiceNumberList').html('<div>No Invoices</div>');
+    }
+});
   
+
 
 // //datepicker and timepicker for popup
     $(document).on("click", ".content", function () {


### PR DESCRIPTION
### What are the changes?

- aeee4a4bc8596c10478a8583616da8109871799e:  Added a new modal to display detailed invoice information. Displayed associated invoice numbers in the payment overview section. Improved visibility of payment-to-invoice relationships for easier tracking  

### Why are these changes needed?

- aeee4a4bc8596c10478a8583616da8109871799e: To provide users with quick access to invoice details without navigating away. To improve clarity and transparency in payment records  

## UI
<img width="1790" height="896" alt="image" src="https://github.com/user-attachments/assets/2ec15a92-131a-46fd-b3de-c2e6ec80341c" />

## Task

Implement invoice popup and ensure loading functionality on the next page
