### PR TITLE
fix: remove accidental character from table markup

### DIFF
--- a/templates/common/productivity/staging-productivity.html
+++ b/templates/common/productivity/staging-productivity.html
@@ -327,7 +327,7 @@
                                                         </div>
                                                     </td>
                                                     <td v-text="`${item.minimum_area} - ${item.maximum_area}`"></td>
-                                                    <td v-text="formatCurrency(item.price)"></td>m
+                                                    <td v-text="formatCurrency(item.price)"></td>
                                                     <td>
                                                         <span
                                                             :class="['status-badge', item.is_active === true ? 'status-active' : 'status-pending']"


### PR DESCRIPTION

### What are the changes?
- c4eb55d8dac8eb40a849b54586f78297c35b438b : Removed the stray m character accidentally left after the table <td> element.

### Why are these changes needed?
- c4eb55d8dac8eb40a849b54586f78297c35b438b : The extra character served no purpose and could introduce unintended UI artifacts or confuse future maintainers. Removing it ensures cleaner code.


