### PR TITLE
fix: correct profile image source binding in resource card

### DIFF
--- a/templates/common/resource/resource-new.html
+++ b/templates/common/resource/resource-new.html
@@ -304,7 +304,7 @@
                                                         <div class="d-flex">
                                                             <div class="resource-card-profile">
                                                                 <img class="resource-img-circle"
-                                                                    :src="worker.profile_image ? worker.profile_image.url : '{% static 'files/icons/profile.png' %}'">
+                                                                    :src="worker.profile_image ? worker.profile_image : '{% static 'files/icons/profile.png' %}'">
                                                                 <span
                                                                     :class="worker.attendanceClass"
                                                                     :id="`attendance_${worker.id}`"></span>


### PR DESCRIPTION

### What are the changes?
- Fixed the profile image source binding issue in the resource card

### Why are these changes needed?
- Profile images were not displaying correctly due to incorrect binding

### How was this tested?
-

### UI
-

### Additional Requirements
-

### Task
- Operation module :- Employees profile not visible
