### PR TITLE
fix: clear service group form title when user clicks the "Add Service Group" button after editing a service group

### DIFF
--- a/static/files/js/staging-productivity.js
+++ b/static/files/js/staging-productivity.js
@@ -143,6 +143,9 @@ createApp({
             this.viewServiceType = {
                 title: '',
             };
+            this.viewServiceGroup = {
+                title: '',
+            };
             this.resetServiceGroup();
             const form = document.getElementById('manage-service-group-form');
             if (form) {


### PR DESCRIPTION

### What are the changes?
- Reset the service group form title when the user clicks the "Add Service Group" button after editing an existing service group

### Why are these changes needed?
- Previously, the form title was not cleared after editing, causing confusion between edit and create states

### How was this tested?
-

### UI
-

### Additional Requirements
-

### Task
- Label change : super admin->Add service group->clicl->add service group button in list-> form heading shows edit service group.
